### PR TITLE
Pc adicionando arquivo gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Gcc Patch
+/*.gcno
+
+# Pods
+Pods/


### PR DESCRIPTION
Felipe, uma prática muito comum é adicionar um .gitignore. Não sei se você já usou, mas este arquivo irá ignorar alguns arquivos que não são necessários de ser adicionados ao repositório do git. Peguei um exemplo pesquisando no google e adicionei o link no commit para você saber de onde veio. Também adicionei o Pods/ Algumas pessoas adicionam ao git os Pods e outras não. Eu já fiz das duas maneiras. Minha preferência é adicionar mas como você não tinha adicionado no seu projeto achei melhor ignorar no gitignore. Podemos falar mais a respeito em alguma live se você tiver dúvida, ou pode perguntar aqui também. Novamente, isso só é uma sugestão. Penso também que você pode até ter um .gitignore no seu projeto porém você não o adicionou no commit. Se este for o caso, aconselho você a adicionar o seu e eu irei atualizar o meu fork.